### PR TITLE
Fix windows path error

### DIFF
--- a/src/main/ts/extension.ts
+++ b/src/main/ts/extension.ts
@@ -186,7 +186,7 @@ function startLanguageServer() {
         };
         let args = [
           "-jar",
-          serverBin.path,
+          serverBin.fsPath,
         ];
         //uncomment to allow a debugger to attach to the language server
         // args.unshift("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005,quiet=y");


### PR DESCRIPTION
This fixes a windows path error where the path to the binary started with `/`.

Closes #9 